### PR TITLE
Only require manager to be set in settings builder

### DIFF
--- a/src/main/java/com/google/cloud/tools/ide/analytics/UsageTrackerSettings.java
+++ b/src/main/java/com/google/cloud/tools/ide/analytics/UsageTrackerSettings.java
@@ -163,14 +163,6 @@ public class UsageTrackerSettings {
     /** Returns a configured {@link UsageTrackerSettings} object. */
     public UsageTrackerSettings build() {
       Preconditions.checkNotNull(manager);
-      Preconditions.checkNotNull(analyticsId);
-      Preconditions.checkNotNull(pageHost);
-      Preconditions.checkNotNull(platformName);
-      Preconditions.checkNotNull(platformVersion);
-      Preconditions.checkNotNull(pluginName);
-      Preconditions.checkNotNull(pluginVersion);
-      Preconditions.checkNotNull(clientId);
-      Preconditions.checkNotNull(userAgent);
 
       return new UsageTrackerSettings(
           manager,

--- a/src/test/java/com/google/cloud/tools/ide/analytics/UsageTrackerSettingsTest.java
+++ b/src/test/java/com/google/cloud/tools/ide/analytics/UsageTrackerSettingsTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.ide.analytics;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import static com.google.common.truth.Truth.assertThat;
+
+/**
+ * Tests for {@link UsageTrackerSettings}.
+ */
+public class UsageTrackerSettingsTest {
+
+    @Test
+    public void buildWithNullManager_throwsException() {
+        try {
+            new UsageTrackerSettings.Builder().build();
+            Assert.fail("NPE exception expected");
+        } catch (NullPointerException npe) {
+            // success, exception expected
+        }
+    }
+
+    @Test
+    public void buildWithNonNullManager_createsSettings() {
+        UsageTrackerSettings settings = new UsageTrackerSettings.Builder().manager(() -> true).build();
+        assertThat(settings).isNotNull();
+    }
+
+}


### PR DESCRIPTION
Upon consuming this library, I realized that it would be better to loosen the requirements on the builder, by only requireing that a `UsageTrackerManager` be provided.

One reason, for example, is that if the analytics ID isn't provided, we still want to create the settings object. Later, the logic (in the manager callback) will check if the ID is provided and if not, return the NoOp usage tracker.